### PR TITLE
Fixed constant names need to be unexported

### DIFF
--- a/parser/cover.txt
+++ b/parser/cover.txt
@@ -1,4 +1,4 @@
-Tested On 06/13/16 01:34:53 PM EDT
+Tested On 06/14/16 04:08:16 PM EDT
 
 github.com/Bridgevine/wsdlgo/parser/generator.go:30:	Write			57.1%
 github.com/Bridgevine/wsdlgo/parser/generator.go:44:	populateElement		84.6%
@@ -22,7 +22,7 @@ github.com/Bridgevine/wsdlgo/parser/sConst.go:27:	resolveType		100.0%
 github.com/Bridgevine/wsdlgo/parser/sField.go:17:	add			100.0%
 github.com/Bridgevine/wsdlgo/parser/sField.go:30:	resolveName		100.0%
 github.com/Bridgevine/wsdlgo/parser/sField.go:38:	resolveType		100.0%
-github.com/Bridgevine/wsdlgo/parser/sField.go:61:	resolveTag		100.0%
+github.com/Bridgevine/wsdlgo/parser/sField.go:56:	resolveTag		100.0%
 github.com/Bridgevine/wsdlgo/parser/sImport.go:7:	add			83.3%
 github.com/Bridgevine/wsdlgo/parser/sMessage.go:10:	add			100.0%
 github.com/Bridgevine/wsdlgo/parser/sStruct.go:11:	add			100.0%

--- a/parser/sConst.go
+++ b/parser/sConst.go
@@ -21,9 +21,9 @@ func (m mapofConsts) add(s sConst) bool {
 }
 
 func (s *sConst) resolveName() {
-	s.Name = lintName(replaceReservedWords(s.Type + s.Value))
+	s.Name = makeUnexported(lintName(replaceReservedWords(s.Type + s.Value)))
 }
 
 func (s *sConst) resolveType() {
-	s.Type = lintName(s.Type)
+	s.Type = makeUnexported(lintName(s.Type))
 }

--- a/parser/sMessage.go
+++ b/parser/sMessage.go
@@ -17,7 +17,7 @@ func (m mapofMessages) add(i string, s string) bool {
 		return false
 	}
 
-	i = toGoType(makeUnexported(lintName(removeNS(i))))
+	i = makeUnexported(lintName(removeNS(i)))
 
 	if v, ok := m[i]; ok {
 		m[i] = sMessage{

--- a/parser/testdata/elements.go
+++ b/parser/testdata/elements.go
@@ -3,8 +3,35 @@
 package types
 
 import (
+	"encoding/xml"
 	"time"
 )
+
+type decimalReqNil struct {
+	*float64
+}
+
+// MarshalXML satisfies the XML Marshaler interface for type decimalReqNil.
+func (t decimalReqNil) MarshalXML(e *xml.Encoder, s xml.StartElement) error {
+	if t.float64 == nil {
+		return e.EncodeElement("", s)
+	}
+
+	return e.EncodeElement(t, s)
+}
+
+type doubleReqNil struct {
+	*float64
+}
+
+// MarshalXML satisfies the XML Marshaler interface for type doubleReqNil.
+func (t doubleReqNil) MarshalXML(e *xml.Encoder, s xml.StartElement) error {
+	if t.float64 == nil {
+		return e.EncodeElement("", s)
+	}
+
+	return e.EncodeElement(t, s)
+}
 
 type echoResponse struct {
 	Attrint    *int32       `xml:"attr-int,attr"`

--- a/parser/testdata/elements.wsdl
+++ b/parser/testdata/elements.wsdl
@@ -16,6 +16,8 @@
       <xs:element name="anyType" nillable="true" type="xs:anyType" />
       <xs:element name="anyURI" nillable="true" type="xs:anyURI" />
       <xs:element name="base64Binary" nillable="true" type="xs:base64Binary" />
+      <xs:element name="decimal" nillable="true" type="xs:decimal"/>
+      <xs:element name="double" nillable="true" type="xs:double"/>
       <xsd:element name="echoele">
         <xsd:complexType>
           <xsd:sequence>

--- a/parser/testdata/simpleType.wsdl
+++ b/parser/testdata/simpleType.wsdl
@@ -29,7 +29,7 @@
           <xsd:pattern value='[a-zA-Z0-9]{18}'/>
         </xsd:restriction>
       </xsd:simpleType>
-      <xsd:simpleType name="uniqueId">
+      <xsd:simpleType name="UniqueId">
         <xsd:restriction base="xsd:string">
           <xsd:enumeration value="1"/>
           <xsd:enumeration value="Html"/>


### PR DESCRIPTION
Remove logic that converted xsd message names to golang types
